### PR TITLE
Support floating calculations in BigNumber and update formula

### DIFF
--- a/Script/Modules/Formula/Formula.cs
+++ b/Script/Modules/Formula/Formula.cs
@@ -19,7 +19,7 @@ public static class Formula
     }
 
     /// <summary>
-    /// 傷害公式： 基本傷害+(累計擊殺加成)^(累計蕃茄鐘加成) 
+    /// 阨`G 禰辣阨`+(眴p[)^(眴pX[)
     /// </summary>
     /// <returns></returns>
     public static BigNumber GetDefaultDamageValue()
@@ -29,7 +29,7 @@ public static class Formula
         BigNumber bigNumber = new BigNumber();
         bigNumber = gameDefaultSetting.defaultClickDamage;
         BigNumber killBonus = 0;
-        int tomatoBonus = 0;
+        float tomatoBonus = 0f;
         IReadOnlyList<EnemyStorageData> enemyStorageDatas = StorageManager.instance.StorageData.GetEnemyStorageDatas();
         foreach (var data in enemyStorageDatas)
         {
@@ -47,7 +47,10 @@ public static class Formula
             }
         }
 
-        eLog.Log($"當前傷害：{bigNumber} + ({killBonus} * (1 +{ tomatoBonus})) = {(bigNumber + (killBonus * (1 + tomatoBonus)))}");
-        return bigNumber + (killBonus * (1+tomatoBonus));
+        BigNumber totalTomatoBonus = tomatoBonus;
+        BigNumber bonusValue = BigNumber.Pow(killBonus, totalTomatoBonus);
+
+        eLog.Log($"e阨`G{bigNumber} + ({killBonus} ^ {totalTomatoBonus}) = {bigNumber + bonusValue}");
+        return bigNumber + bonusValue;
     }
 }


### PR DESCRIPTION
## Summary
- add fixed-point scaling to BigNumber so it can represent and operate on floating point values
- extend BigNumber with new conversions, operations, and formatting helpers for decimal support
- update the default damage calculation to use the new base + (total bonus) ^ (total tomato bonus) formula

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dd39c991988322985d3ae8b10b8eaa