### PR TITLE
Add TextAnimatorManager API and talk data support

### DIFF
--- a/AssetResources/Database/Scripts/Role/RoleData.cs
+++ b/AssetResources/Database/Scripts/Role/RoleData.cs
@@ -60,6 +60,10 @@ namespace GameCore.Database
         [SerializeField]
         private string m_roleIconkey;
 
+        [LabelText("對話資料")]
+        [SerializeField]
+        private TalkScriptableObject m_talkScriptableObject; // 指定角色可使用的對話 ScriptableObject
+
         public int roleSortId => m_roleSortId;
         public string RoleName => m_roleName;
         public string RoleDescription => m_roleDescription;
@@ -73,6 +77,7 @@ namespace GameCore.Database
         public Sprite EnemyIcon => m_enemyIcon;
         public int KillBonus => m_killBonus;
         public int TomatoBonus => m_tomatoBouns;
+        public TalkScriptableObject TalkScriptableObject => m_talkScriptableObject; // 讓外部取得對話 ScriptableObject 以便顯示對話
         public bool ValidateFlagReferenceConditions()
         {
             if (m_flagReferenceConditions == null || m_flagReferenceConditions.Length == 0)

--- a/AssetResources/Database/Scripts/Role/TalkScriptableObject.cs
+++ b/AssetResources/Database/Scripts/Role/TalkScriptableObject.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+namespace GameCore.Database
+{
+    // 定義對話觸發條件的分類
+    public enum TalkConditionType
+    {
+        None = 0, // 無條件，任何情況都能觸發
+        Flag = 1, // 需要檢查旗標是否成立
+        RemainingHealthTimes = 2 // 依據角色剩餘血量次數判斷是否觸發
+    }
+
+    // 定義單一對話觸發條件的資料結構
+    [Serializable]
+    public class TalkCondition
+    {
+        [SerializeField]
+        [LabelText("條件類型")]
+        private TalkConditionType m_conditionType = TalkConditionType.None; // 條件分類，對應旗標或血量次數
+
+        [SerializeField]
+        [LabelText("旗標條件")]
+        [ShowIf(nameof(m_conditionType), TalkConditionType.Flag)]
+        private FlagReference m_flagReference; // 條件類型為旗標時所需的旗標參考
+
+        [SerializeField]
+        [LabelText("剩餘血量次數")]
+        [ShowIf(nameof(m_conditionType), TalkConditionType.RemainingHealthTimes)]
+        private int m_remainingHealthTimes; // 條件類型為血量次數時所需的閾值設定
+
+        public TalkConditionType ConditionType => m_conditionType; // 讓外部讀取條件類型
+
+        public FlagReference FlagReference => m_flagReference; // 讓外部讀取旗標條件
+
+        public int RemainingHealthTimes => m_remainingHealthTimes; // 讓外部讀取血量次數條件
+    }
+
+    // 定義符合條件後要播放的對話條目
+    [Serializable]
+    public class TalkEntry
+    {
+        [SerializeField]
+        [LabelText("觸發條件清單")]
+        private List<TalkCondition> m_conditions = new List<TalkCondition>(); // 單筆對話條目所有的觸發條件
+
+        [SerializeField]
+        [LabelText("對話字串列表")]
+        private List<string> m_dialogLocalizationKeys = new List<string>(); // 觸發時要播放的在地化字串鍵值
+
+        public IReadOnlyList<TalkCondition> Conditions => m_conditions; // 提供唯讀的條件列表給外部使用
+
+        public IReadOnlyList<string> DialogLocalizationKeys => m_dialogLocalizationKeys; // 提供唯讀的對話字串鍵值列表
+    }
+
+    // 提供編輯器建立對話資料用的 ScriptableObject
+    [CreateAssetMenu(menuName = "GameCore/Role/Talk Scriptable Object", fileName = "TalkScriptableObject")]
+    public class TalkScriptableObject : ScriptableObject
+    {
+        [SerializeField]
+        [LabelText("對話條目列表")]
+        private List<TalkEntry> m_talkEntries = new List<TalkEntry>(); // 儲存所有可用的對話條目
+
+        public IReadOnlyList<TalkEntry> TalkEntries => m_talkEntries; // 對話條目的唯讀介面，方便外部查詢
+
+        public TalkEntry GetRandomEntry()
+        {
+            // 若無資料則回傳 null，避免隨機取值時出現例外
+            if (m_talkEntries == null || m_talkEntries.Count == 0)
+            {
+                return null;
+            }
+
+            // 從所有條目中隨機挑選一筆回傳
+            int index = UnityEngine.Random.Range(0, m_talkEntries.Count);
+            return m_talkEntries[index];
+        }
+
+        public IReadOnlyList<string> GetRandomDialogLocalizationKeys()
+        {
+            // 透過隨機條目直接取得對話字串列表，若沒有資料則回傳空陣列避免 Null 參考
+            TalkEntry entry = GetRandomEntry();
+            return entry != null ? entry.DialogLocalizationKeys : Array.Empty<string>();
+        }
+    }
+}

--- a/Script/UI/TextAnimatorManager.cs
+++ b/Script/UI/TextAnimatorManager.cs
@@ -1,16 +1,44 @@
+using Febucci.UI;
 using UnityEngine;
 
 public class TextAnimatorManager : MonoBehaviour
 {
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    [SerializeField]
+    [Tooltip("預設會執行打字機效果的 TextAnimatorPlayer 物件")]
+    private TextAnimatorPlayer m_defaultPlayer; // 預設的 TextAnimatorPlayer 參考，方便在 Prefab 內直接指定
+
+    private TextAnimatorPlayer m_runtimePlayer; // 於執行時使用的 TextAnimatorPlayer 參考，若未指定則退回預設值
+
+    private void Awake()
     {
-        
+        // 初始化時預設使用 Inspector 指定的 TextAnimatorPlayer
+        m_runtimePlayer = m_defaultPlayer;
     }
 
-    // Update is called once per frame
-    void Update()
+    public void SetPlayer(TextAnimatorPlayer player)
     {
-        
+        // 允許外部指定要使用的 TextAnimatorPlayer，若傳入為 null 則仍會使用預設值
+        m_runtimePlayer = player;
+    }
+
+    public void PlayText(string text, bool skipTypewriter = false)
+    {
+        // 取得實際要使用的 TextAnimatorPlayer，若兩者皆為 null 則直接警示並離開
+        TextAnimatorPlayer targetPlayer = m_runtimePlayer != null ? m_runtimePlayer : m_defaultPlayer;
+        if (targetPlayer == null)
+        {
+            Debug.LogWarning("TextAnimatorManager: 未設定 TextAnimatorPlayer，無法播放文字動畫");
+            return;
+        }
+
+        // 設定要顯示的文字並啟動打字機效果
+        targetPlayer.ShowText(text);
+        targetPlayer.StartShowingText(true);
+
+        // 若需要直接跳過打字效果則呼叫 SkipTypewriter 立即顯示全部文字
+        if (skipTypewriter)
+        {
+            targetPlayer.SkipTypewriter();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a configurable TextAnimatorManager API so text animations can be triggered directly and bound to prefab references
- create a TalkScriptableObject that stores condition-based dialogue entries and provides random selection helpers
- allow RoleData to reference the new talk ScriptableObject for role-specific dialogue configuration

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68deaf94cc008322a279656617b320ee