### PR TITLE
Add Role talk scriptable object tooling and importer

### DIFF
--- a/AssetResources/Database/Scripts/Role/RoleData.cs
+++ b/AssetResources/Database/Scripts/Role/RoleData.cs
@@ -60,6 +60,9 @@ namespace GameCore.Database
         [SerializeField]
         private string m_roleIconkey;
 
+        [SerializeField]
+        private TalkScriptableObject m_talkScriptableObject;
+
         public int roleSortId => m_roleSortId;
         public string RoleName => m_roleName;
         public string RoleDescription => m_roleDescription;
@@ -73,6 +76,7 @@ namespace GameCore.Database
         public Sprite EnemyIcon => m_enemyIcon;
         public int KillBonus => m_killBonus;
         public int TomatoBonus => m_tomatoBouns;
+        public TalkScriptableObject TalkScriptableObject => m_talkScriptableObject;
         public bool ValidateFlagReferenceConditions()
         {
             if (m_flagReferenceConditions == null || m_flagReferenceConditions.Length == 0)
@@ -96,6 +100,12 @@ namespace GameCore.Database
         }
 
 #if UNITY_EDITOR
+        public void Editor_SetTalkScriptableObject(TalkScriptableObject talkScriptableObject)
+        {
+            m_talkScriptableObject = talkScriptableObject;
+            EditorUtility.SetDirty(this);
+        }
+
         public void SetSprite()
         {
             string[] guids = AssetDatabase.FindAssets($"t:Sprite {m_roleIconkey}");

--- a/Modules/TalkScriptableObject/Editor/TalkScriptableObjectEditorUtility.cs
+++ b/Modules/TalkScriptableObject/Editor/TalkScriptableObjectEditorUtility.cs
@@ -1,0 +1,184 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using GameCore.Database;
+using GameCore.Database.Editor;
+using UnityEditor;
+using UnityEngine;
+
+internal static class TalkScriptableObjectEditorUtility
+{
+    internal const string FolderPath = "Assets/Modules/TalkScriptableObject";
+
+    internal static string EnsureFolder()
+    {
+        if (AssetDatabase.IsValidFolder("Assets/Modules") == false)
+        {
+            if (AssetDatabase.IsValidFolder("Assets") == false)
+            {
+                throw new DirectoryNotFoundException("Assets folder not found.");
+            }
+
+            AssetDatabase.CreateFolder("Assets", "Modules");
+        }
+
+        if (AssetDatabase.IsValidFolder(FolderPath) == false)
+        {
+            AssetDatabase.CreateFolder("Assets/Modules", "TalkScriptableObject");
+        }
+
+        return FolderPath;
+    }
+
+    internal static TalkScriptableObject GetOrCreateTalkAsset(int roleId)
+    {
+        string folder = EnsureFolder();
+        string assetPath = $"{folder}/Role_{roleId:000}_Talk.asset";
+        var talkAsset = AssetDatabase.LoadAssetAtPath<TalkScriptableObject>(assetPath);
+        if (talkAsset == null)
+        {
+            talkAsset = ScriptableObject.CreateInstance<TalkScriptableObject>();
+            AssetDatabase.CreateAsset(talkAsset, assetPath);
+        }
+
+        return talkAsset;
+    }
+
+    internal static TalkScriptableObject GetOrCreateTalkAssetByName(string assetName)
+    {
+        string folder = EnsureFolder();
+        string fileName = assetName.EndsWith(".asset", StringComparison.OrdinalIgnoreCase) ? assetName : assetName + ".asset";
+        string assetPath = Path.Combine(folder, fileName).Replace("\\", "/");
+        var talkAsset = AssetDatabase.LoadAssetAtPath<TalkScriptableObject>(assetPath);
+        if (talkAsset == null)
+        {
+            talkAsset = ScriptableObject.CreateInstance<TalkScriptableObject>();
+            AssetDatabase.CreateAsset(talkAsset, assetPath);
+        }
+
+        return talkAsset;
+    }
+
+    internal static void ApplyEntries(TalkScriptableObject asset, IReadOnlyList<TalkScriptableObjectName> entries)
+    {
+        if (asset == null)
+        {
+            return;
+        }
+
+        asset.Editor_SetEntries(entries);
+        EditorUtility.SetDirty(asset);
+    }
+
+    internal static int GetRoleId(RoleData role)
+    {
+        if (role == null)
+        {
+            return -1;
+        }
+
+        var serializedObject = new SerializedObject(role);
+        string[] propertyNames =
+        {
+            "m_id",
+            "m_ID",
+            "m_dataID",
+            "m_dataId",
+            "m_Id",
+            "id",
+            "ID",
+            "dataID",
+            "dataId",
+            "m_comment"
+        };
+
+        foreach (string propertyName in propertyNames)
+        {
+            SerializedProperty property = serializedObject.FindProperty(propertyName);
+            if (property == null)
+            {
+                continue;
+            }
+
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Integer:
+                    return property.intValue;
+                case SerializedPropertyType.String:
+                    if (int.TryParse(property.stringValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed))
+                    {
+                        return parsed;
+                    }
+                    break;
+                case SerializedPropertyType.Float:
+                    return Mathf.RoundToInt(property.floatValue);
+            }
+        }
+
+        return -1;
+    }
+
+    internal static bool TryAssignToRole(TalkScriptableObject talkAsset, string assetName, IDictionary<int, RoleData> roleLookup = null)
+    {
+        if (talkAsset == null)
+        {
+            return false;
+        }
+
+        int roleId = ExtractRoleIdFromName(assetName);
+        if (roleId < 0)
+        {
+            return false;
+        }
+
+        roleLookup ??= BuildRoleLookup();
+        if (roleLookup != null && roleLookup.TryGetValue(roleId, out RoleData roleData) && roleData != null)
+        {
+            if (roleData.TalkScriptableObject != talkAsset)
+            {
+                roleData.Editor_SetTalkScriptableObject(talkAsset);
+                DatabaseEditorUtils.SaveData(roleData);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static Dictionary<int, RoleData> BuildRoleLookup()
+    {
+        var roles = DatabaseEditorUtils.GetDatas<RoleData>();
+        var lookup = new Dictionary<int, RoleData>();
+        foreach (RoleData role in roles)
+        {
+            int id = GetRoleId(role);
+            if (id >= 0 && lookup.ContainsKey(id) == false)
+            {
+                lookup.Add(id, role);
+            }
+        }
+
+        return lookup;
+    }
+
+    internal static int ExtractRoleIdFromName(string assetName)
+    {
+        if (string.IsNullOrEmpty(assetName))
+        {
+            return -1;
+        }
+
+        Match match = Regex.Match(assetName, @"\d+");
+        if (match.Success && int.TryParse(match.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed))
+        {
+            return parsed;
+        }
+
+        return -1;
+    }
+}
+#endif

--- a/Modules/TalkScriptableObject/Editor/TalkScriptableObjectGenerator.cs
+++ b/Modules/TalkScriptableObject/Editor/TalkScriptableObjectGenerator.cs
@@ -1,0 +1,40 @@
+#if UNITY_EDITOR
+using GameCore.Database;
+using GameCore.Database.Editor;
+using UnityEditor;
+
+public static class TalkScriptableObjectGenerator
+{
+    [MenuItem("Tools/Talk/Generate Role Talk Assets")]
+    private static void GenerateRoleTalkAssets()
+    {
+        TalkScriptableObjectEditorUtility.EnsureFolder();
+        var roles = DatabaseEditorUtils.GetDatas<RoleData>();
+        bool updated = false;
+
+        foreach (RoleData role in roles)
+        {
+            int roleId = TalkScriptableObjectEditorUtility.GetRoleId(role);
+            if (roleId < 0)
+            {
+                continue;
+            }
+
+            TalkScriptableObject talkAsset = TalkScriptableObjectEditorUtility.GetOrCreateTalkAsset(roleId);
+            if (role.TalkScriptableObject != talkAsset)
+            {
+                role.Editor_SetTalkScriptableObject(talkAsset);
+                DatabaseEditorUtils.SaveData(role);
+                updated = true;
+            }
+        }
+
+        if (updated)
+        {
+            AssetDatabase.SaveAssets();
+        }
+
+        AssetDatabase.Refresh();
+    }
+}
+#endif

--- a/Modules/TalkScriptableObject/Editor/TalkScriptableObjectSheetImporter.cs
+++ b/Modules/TalkScriptableObject/Editor/TalkScriptableObjectSheetImporter.cs
@@ -1,0 +1,173 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using GameCore.Database;
+using GameCore.Database.Editor;
+using UnityEditor;
+using UnityEngine;
+
+internal static class TalkScriptableObjectSheetImporter
+{
+    private static readonly string[] s_headerKeywords =
+    {
+        "檔名",
+        "TalkScriptableObjectName",
+        "對話內容",
+        "執行秒數"
+    };
+
+    internal static void Import(string rawContent)
+    {
+        if (string.IsNullOrWhiteSpace(rawContent))
+        {
+            Debug.LogWarning("Talk sheet content is empty.");
+            return;
+        }
+
+        TalkScriptableObjectEditorUtility.EnsureFolder();
+
+        Dictionary<int, RoleData> roleLookup = null;
+        TalkScriptableObject currentAsset = null;
+        string currentAssetName = string.Empty;
+        var entries = new List<TalkScriptableObjectName>();
+
+        string[] lines = rawContent.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None);
+        foreach (string rawLine in lines)
+        {
+            if (string.IsNullOrWhiteSpace(rawLine))
+            {
+                continue;
+            }
+
+            string[] columns = SplitColumns(rawLine);
+            if (columns.Length == 0)
+            {
+                continue;
+            }
+
+            string firstColumn = columns[0].Trim();
+            if (string.IsNullOrEmpty(firstColumn) || IsHeader(firstColumn))
+            {
+                continue;
+            }
+
+            bool startsNewAsset = ShouldStartNewAsset(columns);
+            if (startsNewAsset)
+            {
+                SaveCurrentAsset();
+
+                currentAssetName = firstColumn;
+                currentAsset = TalkScriptableObjectEditorUtility.GetOrCreateTalkAssetByName(currentAssetName);
+                roleLookup ??= BuildRoleLookup();
+                TalkScriptableObjectEditorUtility.TryAssignToRole(currentAsset, currentAssetName, roleLookup);
+                entries.Clear();
+                continue;
+            }
+
+            if (currentAsset == null)
+            {
+                Debug.LogWarning($"Encountered talk content without an assigned TalkScriptableObject name: {rawLine}");
+                continue;
+            }
+
+            string content = columns[0];
+            float duration = ParseDuration(columns, 1);
+            entries.Add(new TalkScriptableObjectName(content, duration));
+        }
+
+        SaveCurrentAsset();
+
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+        Debug.Log("Talk Scriptable Objects imported successfully.");
+
+        void SaveCurrentAsset()
+        {
+            if (currentAsset == null)
+            {
+                return;
+            }
+
+            TalkScriptableObjectEditorUtility.ApplyEntries(currentAsset, entries);
+        }
+    }
+
+    private static Dictionary<int, RoleData> BuildRoleLookup()
+    {
+        var roles = DatabaseEditorUtils.GetDatas<RoleData>();
+        var lookup = new Dictionary<int, RoleData>();
+        foreach (RoleData role in roles)
+        {
+            int id = TalkScriptableObjectEditorUtility.GetRoleId(role);
+            if (id >= 0 && lookup.ContainsKey(id) == false)
+            {
+                lookup.Add(id, role);
+            }
+        }
+
+        return lookup;
+    }
+
+    private static string[] SplitColumns(string rawLine)
+    {
+        string[] columns = rawLine.Split('\t');
+        if (columns.Length <= 1)
+        {
+            columns = rawLine.Split(',');
+        }
+
+        return columns;
+    }
+
+    private static bool ShouldStartNewAsset(string[] columns)
+    {
+        if (columns.Length <= 1)
+        {
+            return true;
+        }
+
+        string secondColumn = columns[1].Trim();
+        if (string.IsNullOrEmpty(secondColumn) || IsHeader(secondColumn))
+        {
+            return true;
+        }
+
+        return float.TryParse(secondColumn, NumberStyles.Float, CultureInfo.InvariantCulture, out _) == false;
+    }
+
+    private static bool IsHeader(string value)
+    {
+        foreach (string keyword in s_headerKeywords)
+        {
+            if (string.Equals(value, keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static float ParseDuration(string[] columns, int index)
+    {
+        if (columns.Length <= index)
+        {
+            return 0f;
+        }
+
+        string value = columns[index].Trim();
+        if (float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out float result))
+        {
+            return result;
+        }
+
+        if (float.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out result))
+        {
+            return result;
+        }
+
+        return 0f;
+    }
+}
+#endif

--- a/Modules/TalkScriptableObject/TalkScriptableObject.cs
+++ b/Modules/TalkScriptableObject/TalkScriptableObject.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TalkScriptableObject", menuName = "Scriptable Objects/Talk Scriptable Object")]
+public class TalkScriptableObject : ScriptableObject
+{
+    [SerializeField]
+    private TalkScriptableObjectName[] m_entries = Array.Empty<TalkScriptableObjectName>();
+
+    public IReadOnlyList<TalkScriptableObjectName> Entries => m_entries;
+
+#if UNITY_EDITOR
+    public void Editor_SetEntries(IReadOnlyList<TalkScriptableObjectName> entries)
+    {
+        if (entries == null || entries.Count == 0)
+        {
+            m_entries = Array.Empty<TalkScriptableObjectName>();
+            return;
+        }
+
+        var array = new TalkScriptableObjectName[entries.Count];
+        for (int i = 0; i < entries.Count; i++)
+        {
+            array[i] = entries[i];
+        }
+
+        m_entries = array;
+    }
+#endif
+}
+
+[Serializable]
+public struct TalkScriptableObjectName
+{
+    [SerializeField, TextArea]
+    private string m_content;
+
+    [SerializeField, Min(0f)]
+    private float m_duration;
+
+    public string Content => m_content;
+
+    public float Duration => m_duration;
+
+    public TalkScriptableObjectName(string content, float duration)
+    {
+        m_content = content;
+        m_duration = duration;
+    }
+}

--- a/Modules/TalkScriptableObject/TalkScriptableObjectImportTool.cs
+++ b/Modules/TalkScriptableObject/TalkScriptableObjectImportTool.cs
@@ -1,0 +1,35 @@
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "TalkScriptableObjectImportTool", menuName = "Scriptable Objects/Talk Scriptable Object Import Tool")]
+public class TalkScriptableObjectImportTool : ScriptableObject
+{
+    [SerializeField]
+    private GoogleSheetDownloaderReference googleSheetDownloaderReference;
+
+#if UNITY_EDITOR
+    [Button("Download & Import")]
+    public void DownloadAndImport()
+    {
+        if (googleSheetDownloaderReference == null)
+        {
+            Debug.LogError("GoogleSheetDownloaderReference is not assigned.");
+            return;
+        }
+
+        googleSheetDownloaderReference.Setup(OnDownloadProgress, OnDownloadFinished);
+        googleSheetDownloaderReference.DownLoad();
+    }
+
+    private void OnDownloadProgress(float progress)
+    {
+        UnityEditor.EditorUtility.DisplayProgressBar("Talk Scriptable Object Import", "Downloading Google Sheet...", progress);
+    }
+
+    private void OnDownloadFinished(string content)
+    {
+        UnityEditor.EditorUtility.ClearProgressBar();
+        TalkScriptableObjectSheetImporter.Import(content);
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- add a TalkScriptableObject asset and entry struct that stores dialogue text and its display duration
- introduce editor tooling to generate talk assets for each RoleData and to import Google Sheet data into those assets
- extend RoleData to keep a reference to its TalkScriptableObject for automated linking

## Testing
- not run (editor tooling only)


------
https://chatgpt.com/codex/tasks/task_e_68dfecc850488322a0e62973311ca141