### PR TITLE
Add talk condition support and sort id talk asset assigner

### DIFF
--- a/Modules/TalkScriptableObject/Editor/TalkScriptableObjectEditorUtility.cs
+++ b/Modules/TalkScriptableObject/Editor/TalkScriptableObjectEditorUtility.cs
@@ -49,9 +49,7 @@ internal static class TalkScriptableObjectEditorUtility
 
     internal static TalkScriptableObject GetOrCreateTalkAssetByName(string assetName)
     {
-        string folder = EnsureFolder();
-        string fileName = assetName.EndsWith(".asset", StringComparison.OrdinalIgnoreCase) ? assetName : assetName + ".asset";
-        string assetPath = Path.Combine(folder, fileName).Replace("\\", "/");
+        string assetPath = BuildAssetPath(assetName);
         var talkAsset = AssetDatabase.LoadAssetAtPath<TalkScriptableObject>(assetPath);
         if (talkAsset == null)
         {
@@ -60,6 +58,12 @@ internal static class TalkScriptableObjectEditorUtility
         }
 
         return talkAsset;
+    }
+
+    internal static TalkScriptableObject LoadTalkAssetByName(string assetName)
+    {
+        string assetPath = BuildAssetPath(assetName);
+        return AssetDatabase.LoadAssetAtPath<TalkScriptableObject>(assetPath);
     }
 
     internal static void ApplyEntries(TalkScriptableObject asset, IReadOnlyList<TalkScriptableObjectName> entries)
@@ -179,6 +183,13 @@ internal static class TalkScriptableObjectEditorUtility
         }
 
         return -1;
+    }
+
+    private static string BuildAssetPath(string assetName)
+    {
+        string folder = EnsureFolder();
+        string fileName = assetName.EndsWith(".asset", StringComparison.OrdinalIgnoreCase) ? assetName : assetName + ".asset";
+        return Path.Combine(folder, fileName).Replace("\\", "/");
     }
 }
 #endif

--- a/Modules/TalkScriptableObject/Editor/TalkScriptableObjectSortIdAssigner.cs
+++ b/Modules/TalkScriptableObject/Editor/TalkScriptableObjectSortIdAssigner.cs
@@ -1,0 +1,53 @@
+#if UNITY_EDITOR
+using GameCore.Database;
+using GameCore.Database.Editor;
+using UnityEditor;
+using UnityEngine;
+
+public static class TalkScriptableObjectSortIdAssigner
+{
+    [MenuItem("Tools/Talk/Assign Role Talk Assets By Sort Id")]
+    private static void AssignRoleTalkAssetsBySortId()
+    {
+        TalkScriptableObjectEditorUtility.EnsureFolder();
+        var roles = DatabaseEditorUtils.GetDatas<RoleData>();
+        bool updated = false;
+
+        foreach (RoleData role in roles)
+        {
+            if (role == null)
+            {
+                continue;
+            }
+
+            int sortId = role.roleSortId;
+            if (sortId < 0)
+            {
+                continue;
+            }
+
+            string assetName = $"Role_{sortId:000}_Talk";
+            TalkScriptableObject talkAsset = TalkScriptableObjectEditorUtility.LoadTalkAssetByName(assetName);
+            if (talkAsset == null)
+            {
+                Debug.LogWarning($"Talk asset not found for sort id {sortId}: {assetName}.asset");
+                continue;
+            }
+
+            if (role.TalkScriptableObject != talkAsset)
+            {
+                role.Editor_SetTalkScriptableObject(talkAsset);
+                DatabaseEditorUtils.SaveData(role);
+                updated = true;
+            }
+        }
+
+        if (updated)
+        {
+            AssetDatabase.SaveAssets();
+        }
+
+        AssetDatabase.Refresh();
+    }
+}
+#endif

--- a/Modules/TalkScriptableObject/TalkScriptableObject.cs
+++ b/Modules/TalkScriptableObject/TalkScriptableObject.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GameCore.Database;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "TalkScriptableObject", menuName = "Scriptable Objects/Talk Scriptable Object")]
@@ -39,13 +40,49 @@ public struct TalkScriptableObjectName
     [SerializeField, Min(0f)]
     private float m_duration;
 
+    [SerializeField]
+    private TalkCondition[] m_conditions;
+
     public string Content => m_content;
 
     public float Duration => m_duration;
 
-    public TalkScriptableObjectName(string content, float duration)
+    public IReadOnlyList<TalkCondition> Conditions => m_conditions ?? Array.Empty<TalkCondition>();
+
+    public TalkScriptableObjectName(string content, float duration, IReadOnlyList<TalkCondition> conditions = null)
     {
         m_content = content;
         m_duration = duration;
+        if (conditions == null || conditions.Count == 0)
+        {
+            m_conditions = Array.Empty<TalkCondition>();
+            return;
+        }
+
+        m_conditions = new TalkCondition[conditions.Count];
+        for (int i = 0; i < conditions.Count; i++)
+        {
+            m_conditions[i] = conditions[i];
+        }
+    }
+}
+
+[Serializable]
+public struct TalkCondition
+{
+    [SerializeField, Min(0)]
+    private int m_remainingCount;
+
+    [SerializeField]
+    private FlagReference m_flagReference;
+
+    public int RemainingCount => m_remainingCount;
+
+    public FlagReference FlagReference => m_flagReference;
+
+    public TalkCondition(int remainingCount, FlagReference flagReference)
+    {
+        m_remainingCount = Mathf.Max(0, remainingCount);
+        m_flagReference = flagReference;
     }
 }


### PR DESCRIPTION
## Summary
- extend talk entries with reusable condition data for remaining counts and flag references
- add an editor utility to load talk assets by name and a tool to bind RoleData by sort id

## Testing
- not run (editor-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e0a0a9f8a88322bff425ac78e4fdc9