### PR TITLE
feat: preview talk localization and battle chatter

### DIFF
--- a/Modules/TalkScriptableObject/TalkScriptableObject.cs
+++ b/Modules/TalkScriptableObject/TalkScriptableObject.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using GameCore.Database;
 using UnityEngine;
+#if UNITY_EDITOR
+using Sirenix.OdinInspector;
+#endif
 
 [CreateAssetMenu(fileName = "TalkScriptableObject", menuName = "Scriptable Objects/Talk Scriptable Object")]
 public class TalkScriptableObject : ScriptableObject
@@ -48,6 +51,12 @@ public struct TalkScriptableObjectName
     public float Duration => m_duration;
 
     public IReadOnlyList<TalkCondition> Conditions => m_conditions ?? Array.Empty<TalkCondition>();
+
+#if UNITY_EDITOR
+    [ShowInInspector, DisplayAsString, LabelText("繁中預覽"), PropertyOrder(-1)]
+    [InfoBox("依據多國語系表顯示的繁體中文內容，僅供檢視", InfoMessageType.None)]
+    private string Editor_LocalizedPreview => TalkScriptableObjectEditorPreviewUtility.GetTraditionalChineseContent(m_content);
+#endif
 
     public TalkScriptableObjectName(string content, float duration, IReadOnlyList<TalkCondition> conditions = null)
     {

--- a/Modules/TalkScriptableObject/TalkScriptableObjectEditorPreviewUtility.cs
+++ b/Modules/TalkScriptableObject/TalkScriptableObjectEditorPreviewUtility.cs
@@ -1,0 +1,66 @@
+#if UNITY_EDITOR
+using UnityEditor.Localization;
+using UnityEngine.Localization;
+using UnityEngine.Localization.Tables;
+
+/// <summary>
+/// 提供 Talk Scriptable Object 在編輯器中預覽繁體中文文本的工具。
+/// </summary>
+internal static class TalkScriptableObjectEditorPreviewUtility
+{
+    private const string TableName = "LocalizationCollection";
+    private const string DefaultLocaleIdentifier = "zh-TW";
+
+    private static StringTable s_cachedTable;
+    private static LocaleIdentifier s_cachedLocaleIdentifier;
+
+    /// <summary>
+    /// 根據傳入的多國語系 Key 讀取繁體中文顯示內容。
+    /// </summary>
+    internal static string GetTraditionalChineseContent(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return string.Empty;
+        }
+
+        EnsureTable();
+
+        if (s_cachedTable == null)
+        {
+            return key;
+        }
+
+        var entry = s_cachedTable.GetEntry(key);
+        return entry != null ? entry.LocalizedValue : key;
+    }
+
+    /// <summary>
+    /// 快取目標字串表，避免每次都重新搜尋資源。
+    /// </summary>
+    private static void EnsureTable()
+    {
+        if (s_cachedTable != null && s_cachedLocaleIdentifier.Code == DefaultLocaleIdentifier)
+        {
+            return;
+        }
+
+        var collection = LocalizationEditorSettings.GetStringTableCollection(TableName);
+        if (collection == null)
+        {
+            s_cachedTable = null;
+            return;
+        }
+
+        var locale = LocalizationEditorSettings.GetLocale(new LocaleIdentifier(DefaultLocaleIdentifier));
+        if (locale == null)
+        {
+            s_cachedTable = null;
+            return;
+        }
+
+        s_cachedLocaleIdentifier = locale.Identifier;
+        s_cachedTable = collection.GetTable(locale.Identifier);
+    }
+}
+#endif

--- a/Script/Modules/Role/RoleSpawnHUD.cs
+++ b/Script/Modules/Role/RoleSpawnHUD.cs
@@ -11,14 +11,34 @@ using UnityEngine.UI;
 public class RoleSpawnHUD : MonoBehaviour, IInitlization
 {
     [Header("UI Components")]
-    [SerializeField] private Image m_enemyImage; // ¼Ä¤H¹Ï¤ù
-    [SerializeField] private TextMeshProUGUI m_enemyHealthText; // ¼Ä¤H¦å¶q¼Æ­È
-    [SerializeField] private TextMeshProUGUI m_enemyNameText; // ¼Ä¤H¦WºÙ
-    [SerializeField] private Image m_enemyHealthBar; // ¼Ä¤H¦å±øªí²{
+    // Ø«eÑ¾lqÑµÔ°OÏ¥Î¡AÎ©P_Ü±
+    public BigNumber CurrentRemainHit => m_curHitCount;
+
+        // lÆ®Ã¼Ä¤HÜ¤rA×§Kİ¯d
+        SetTalkContent(string.Empty);
+    /// <summary>
+    /// Ü¼Ä¤HÜ¤eAÅ¦rÉ¦Û°rC
+    /// </summary>
+    public void SetTalkContent(string content)
+    {
+        if (m_enemyNameText == null)
+        {
+            return;
+        }
+
+        bool hasContent = string.IsNullOrEmpty(content) == false;
+        m_enemyNameText.gameObject.SetActive(hasContent);
+        m_enemyNameText.text = hasContent ? content : string.Empty;
+    }
+
+    [SerializeField] private Image m_enemyImage; // æ•µäººåœ–ç‰‡
+    [SerializeField] private TextMeshProUGUI m_enemyHealthText; // æ•µäººè¡€é‡æ•¸å€¼
+    [SerializeField] private TextMeshProUGUI m_enemyNameText; // æ•µäººåç¨±
+    [SerializeField] private Image m_enemyHealthBar; // æ•µäººè¡€æ¢è¡¨ç¾
     [SerializeField] private RectTransform m_enemyRect;
     private Action<bool> m_dieActionCallBack;
-    private BigNumber m_maxHitCount; // ³Ì¤j¦å¶q
-    private BigNumber m_curHitCount; // ·í«e¦å¶q
+    private BigNumber m_maxHitCount; // æœ€å¤§è¡€é‡
+    private BigNumber m_curHitCount; // ç•¶å‰è¡€é‡
 
     public void Initlization(Action callBack = null)
     {
@@ -26,7 +46,7 @@ public class RoleSpawnHUD : MonoBehaviour, IInitlization
         m_enemyImage.sprite = null;
         m_enemyHealthText.text = "0";
         //m_enemyNameText.text = "Enemy";
-        m_enemyHealthBar.fillAmount = 1f; // ¹w³]¦å±ø¬°º¡
+        m_enemyHealthBar.fillAmount = 1f; // é è¨­è¡€æ¢ç‚ºæ»¿
         m_dieActionCallBack = null;
         m_enemyRect = m_enemyImage.GetComponent<RectTransform>();
     }
@@ -37,29 +57,29 @@ public class RoleSpawnHUD : MonoBehaviour, IInitlization
     }
 
     /// <summary>
-    /// ¸ü¤J¼Ä¤H¸ê®Æ
+    /// è¼‰å…¥æ•µäººè³‡æ–™
     /// </summary>
     /// <param name="roleData"></param>
     public void LoadRoleData(RoleData roleData)
     {
-        // ¨ú±o¼Ä¤H¹Ï¤ù
+        // å–å¾—æ•µäººåœ–ç‰‡
         m_enemyImage.sprite = roleData.EnemyIcon;
         m_enemyImage.enabled = m_enemyImage.sprite != null;
-        // ¨ú±o¼Ä¤H¦WºÙ
+        // å–å¾—æ•µäººåç¨±
         // m_enemyNameText.text = roleData.RoleName;
 
         m_maxHitCount = roleData.HitCount;
         m_curHitCount = roleData.HitCount;
-        // §ó·s¦å±øªí²{
+        // æ›´æ–°è¡€æ¢è¡¨ç¾
         UpdateHealthBar(roleData.HitCount, roleData.HitCount);
 
         float rotationY = roleData.DirectionType == DirectionType.Right ? 180f : 0f;
-        m_enemyRect.localEulerAngles = new UnityEngine.Vector3(0, rotationY, 0); // ­±¦V¥kÃä
+        m_enemyRect.localEulerAngles = new UnityEngine.Vector3(0, rotationY, 0); // é¢å‘å³é‚Š
 
     }
 
     /// <summary>
-    /// ¸ü¤J³Ì«á¾Ô°«¤¤ªº¼Ä¤H¸ê®Æ
+    /// è¼‰å…¥æœ€å¾Œæˆ°é¬¥ä¸­çš„æ•µäººè³‡æ–™
     /// </summary>
     /// <param name="battleStorageData"></param>
     public void ApplyBattleStorageData(BattleStorageData battleStorageData)
@@ -75,14 +95,14 @@ public class RoleSpawnHUD : MonoBehaviour, IInitlization
     }
 
     /// <summary>
-    /// §ó·s¼Ä¤H¦å±øªí²{
+    /// æ›´æ–°æ•µäººè¡€æ¢è¡¨ç¾
     /// </summary>
-    /// <param name="currentHealth">·í«e¦å¶q</param>
-    /// <param name="maxHealth">³Ì¤j¦å¶q</param>
+    /// <param name="currentHealth">ç•¶å‰è¡€é‡</param>
+    /// <param name="maxHealth">æœ€å¤§è¡€é‡</param>
     private void UpdateHealthBar(BigNumber currentHealth, BigNumber maxHealth)
     {
         m_enemyHealthText.text = $"{m_curHitCount}/{m_maxHitCount}";
-        // ­pºâ¦å¶q¦Ê¤À¤ñ
+        // è¨ˆç®—è¡€é‡ç™¾åˆ†æ¯”
         m_enemyHealthBar.fillAmount = (float)((double)currentHealth.Value / (double)maxHealth.Value);
     }
 
@@ -117,14 +137,14 @@ public class RoleSpawnHUD : MonoBehaviour, IInitlization
 
     private void Shake()
     {
-        // ¹Ï¤ù¾_°Ê(0.1¬í)¡A¨Ï¥Î Tween
+        // åœ–ç‰‡éœ‡å‹•(0.1ç§’)ï¼Œä½¿ç”¨ Tween
         ShakeSettings shakeSettings = new()
         {
-            // «Ø¥ßÂ²©öªº¾_°Ê®ÄªG
+            // å»ºç«‹ç°¡æ˜“çš„éœ‡å‹•æ•ˆæœ
             duration = 0.1f,
-            strength = UnityEngine.Random.insideUnitSphere * 5, // ¾_°Ê±j«×
-            cycles = 1, // ¾_°Ê¦¸¼Æ
-            easeBetweenShakes = Ease.OutSine, // ¾_°Ê¹L´ç®ÄªG
+            strength = UnityEngine.Random.insideUnitSphere * 5, // éœ‡å‹•å¼·åº¦
+            cycles = 1, // éœ‡å‹•æ¬¡æ•¸
+            easeBetweenShakes = Ease.OutSine, // éœ‡å‹•éæ¸¡æ•ˆæœ
             frequency = 3,
         };
         PrimeTween.Tween.PunchLocalPosition(m_enemyRect, shakeSettings);

--- a/Script/UI/2.GameMain/Battle/BattlePanel.cs
+++ b/Script/UI/2.GameMain/Battle/BattlePanel.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using GameCore.Database;
 using GameCore.Event;
 using GameCore.Log;
@@ -34,8 +36,13 @@ public class BattlePanel : PanelBase
     private EventListener m_eventListener;
     private RoleData m_curBattleRole;
     private bool m_isAlive = false;
-    private int m_tomatoHitStack = 0; // ¿»­XÄÁ´Á¶¡²Ö¿nªº¶Ë®`¦¸¼Æ
-    private BigNumber m_curHitValue = 0;  // ·í«eÂIÀ»¶Ë®`
+    // Ä¤HÜ½{
+    private Coroutine m_enemyTalkCoroutine;
+    // Æ§QÎªÖ¨MAÎ©ziÎªÜ¤e
+    private readonly List<TalkScriptableObjectName> m_talkCandidates = new List<TalkScriptableObjectName>();
+
+    private int m_tomatoHitStack = 0; // è•ƒèŒ„é˜æœŸé–“ç´¯ç©çš„å‚·å®³æ¬¡æ•¸
+    private BigNumber m_curHitValue = 0;  // ç•¶å‰é»æ“Šå‚·å®³
     public override void Initlization(Action callBack = null)
     {
         base.Initlization(callBack);
@@ -64,8 +71,8 @@ public class BattlePanel : PanelBase
     }
 
     /// <summary>
-    /// §ó·sÀ»¥´¼Æ­È
-    /// ­«¿ï¨¤¦â®É§ó·s
+    /// æ›´æ–°æ“Šæ‰“æ•¸å€¼
+    /// é‡é¸è§’è‰²æ™‚æ›´æ–°
     /// </summary>
     private void HitValueUpdate()
     {
@@ -106,7 +113,203 @@ public class BattlePanel : PanelBase
     {
         if (Database<RoleData>.TryLoad(eventData.roleKey, out var data))
         {
-            eLog.Log($"³]©w·í«e³Ì«á¾Ô°«¨¤¦â¸ê®Æ¡G{data.key} ¡A³Ñ¾l¦¸¼Æ¡G{data.HitCount}");
+            StartEnemyTalkRoutine(); // sÒ°Ê¼Ä¤HÜ¬y{
+        }
+        else
+        {
+            StopEnemyTalkRoutine();
+            if (Database<RoleData>.TryLoad(StorageManager.instance.StorageData.BattleStorageData.EnemyKey, out var roleData))
+            {
+                m_curBattleRole = roleData;
+                UpdateSceneBackground(roleData.SceneReference.Load());
+                StartEnemyTalkRoutine(); // qxsÙ­É¤]nÜ¼Ä¤H
+            }
+            else
+            {
+                StopEnemyTalkRoutine();
+            }
+        StopEnemyTalkRoutine(); // OÉ°Ä¤H
+        StopEnemyTalkRoutine(); // Ä¤H`É°Ü½
+    // Ò°Ê¼Ä¤HÜªy{A|Ì¾Ú³]wÆ½
+    private void StartEnemyTalkRoutine()
+    {
+        StopEnemyTalkRoutine();
+
+        if (m_enemySpawn == null)
+        {
+            return;
+        }
+
+        if (m_curBattleRole == null || m_curBattleRole.TalkScriptableObject == null)
+        {
+            m_enemySpawn.SetTalkContent(string.Empty);
+            return;
+        }
+
+        var talkAsset = m_curBattleRole.TalkScriptableObject;
+        if (talkAsset.Entries == null || talkAsset.Entries.Count == 0)
+        {
+            m_enemySpawn.SetTalkContent(string.Empty);
+            return;
+        }
+
+        // Ï¥Î¨{Ì§H
+        m_enemyTalkCoroutine = StartCoroutine(EnemyTalkRoutine(talkAsset));
+    }
+
+    // Ä¤HÜ¨Ã²MÜ¤r
+    private void StopEnemyTalkRoutine()
+    {
+        if (m_enemyTalkCoroutine != null)
+        {
+            StopCoroutine(m_enemyTalkCoroutine);
+            m_enemyTalkCoroutine = null;
+        }
+
+        if (m_enemySpawn != null)
+        {
+            m_enemySpawn.SetTalkContent(string.Empty);
+        }
+    }
+
+    // Ä¤HÜ¨{GÌ¾ TalkScriptableObject Æ½e
+    private IEnumerator EnemyTalkRoutine(TalkScriptableObject talkAsset)
+    {
+        while (true)
+        {
+            if (talkAsset == null || m_curBattleRole == null || m_curBattleRole.TalkScriptableObject != talkAsset)
+            {
+                m_enemySpawn?.SetTalkContent(string.Empty);
+                yield break;
+            }
+
+            if (!active || m_isAlive == false)
+            {
+                m_enemySpawn?.SetTalkContent(string.Empty);
+                yield return null;
+                continue;
+            }
+
+            if (!TryGetRandomTalkEntry(talkAsset, out var talkEntry))
+            {
+                m_enemySpawn?.SetTalkContent(string.Empty);
+                yield return null;
+                continue;
+            }
+
+            string localizedContent = GetLocalizedTalkContent(talkEntry.Content);
+            m_enemySpawn?.SetTalkContent(localizedContent);
+
+            float duration = Mathf.Max(0.5f, talkEntry.Duration);
+            float elapsed = 0f;
+            while (elapsed < duration)
+            {
+                if (!active || m_isAlive == false || m_curBattleRole == null || m_curBattleRole.TalkScriptableObject != talkAsset)
+                {
+                    break;
+                }
+
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+
+            if (!active || m_isAlive == false)
+            {
+                m_enemySpawn?.SetTalkContent(string.Empty);
+            }
+
+            yield return null;
+        }
+    }
+
+    // Õ¨oÅ¦XHÜ±
+    private bool TryGetRandomTalkEntry(TalkScriptableObject talkAsset, out TalkScriptableObjectName talkEntry)
+    {
+        var entries = talkAsset.Entries;
+        m_talkCandidates.Clear();
+
+        if (entries != null)
+        {
+            for (int i = 0; i < entries.Count; i++)
+            {
+                var entry = entries[i];
+                if (IsTalkEntryValid(entry))
+                {
+                    m_talkCandidates.Add(entry);
+                }
+            }
+        }
+
+        if (m_talkCandidates.Count == 0)
+        {
+            talkEntry = default;
+            return false;
+        }
+
+        talkEntry = m_talkCandidates[UnityEngine.Random.Range(0, m_talkCandidates.Count)];
+        return true;
+    }
+
+    // Ë¬dÜ±O_
+    private bool IsTalkEntryValid(TalkScriptableObjectName entry)
+    {
+        var conditions = entry.Conditions;
+        if (conditions == null || conditions.Count == 0)
+        {
+            return true;
+        }
+
+        for (int i = 0; i < conditions.Count; i++)
+        {
+            var condition = conditions[i];
+
+            if (condition.RemainingCount > 0 && m_enemySpawn != null)
+            {
+                if (m_enemySpawn.CurrentRemainHit > condition.RemainingCount)
+                {
+                    return false;
+                }
+            }
+
+            var flagReference = condition.FlagReference;
+            if (flagReference != null)
+            {
+                if (flagReference.TryLoad(out var flagData))
+                {
+                    var storageData = StorageManager.instance?.StorageData;
+                    if (storageData == null)
+                    {
+                        return false;
+                    }
+
+                    if (storageData.GetFlagStorageValue(flagData.key) <= 0)
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    eLog.Error($"ä¤£XĞ¸Æ¡G{flagReference.GetKey()}");
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    // Nhyt key à¦¨Ü¤r
+    private string GetLocalizedTalkContent(string key)
+    {
+        if (string.IsNullOrEmpty(key))
+        {
+            return string.Empty;
+        }
+
+        return LocalizationManager.instance != null ? LocalizationManager.instance.GetLocalization(key) : key;
+    }
+
+            eLog.Log($"è¨­å®šç•¶å‰æœ€å¾Œæˆ°é¬¥è§’è‰²è³‡æ–™ï¼š{data.key} ï¼Œå‰©é¤˜æ¬¡æ•¸ï¼š{data.HitCount}");
             StorageManager.instance.StorageData.ApplyLastBattleStorageData(data.key, data.HitCount);
             HitValueUpdate();
             m_curBattleRole = data;
@@ -122,9 +325,9 @@ public class BattlePanel : PanelBase
 
     public override void ActiveOn()
     {
-        // ½T»{¬O§_¦³³Ì«á¾Ô°«¸ê®Æ
+        // ç¢ºèªæ˜¯å¦æœ‰æœ€å¾Œæˆ°é¬¥è³‡æ–™
         bool hasBattleData = string.IsNullOrEmpty(StorageManager.instance.StorageData.BattleStorageData.EnemyKey) == false;
-        // Åª¨ú³Ì«á°O¿ı¤¤ªº³õ´º
+        // è®€å–æœ€å¾Œè¨˜éŒ„ä¸­çš„å ´æ™¯
         if (hasBattleData)
         {
             m_enemySpawn.ApplyBattleStorageData(StorageManager.instance.StorageData.BattleStorageData);
@@ -134,7 +337,7 @@ public class BattlePanel : PanelBase
             SettingsManager.instance.setting.defaultEnemyReference.TryLoad(out m_curBattleRole);
             if (m_curBattleRole == null)
             {
-                eLog.Error("¥¼³]©w¹w³]¾Ô°«¨¤¦â¡A½Ğ­«·sÀË¬d³]©wÀÉ¡C");
+                eLog.Error("æœªè¨­å®šé è¨­æˆ°é¬¥è§’è‰²ï¼Œè«‹é‡æ–°æª¢æŸ¥è¨­å®šæª”ã€‚");
                 return;
             }
             CreateBattleEnemy();
@@ -148,7 +351,7 @@ public class BattlePanel : PanelBase
         BattleManager.instance.Register(null);
     }
 
-    // ­«·s«ü©w¥Í¦¨¼Ä¤H
+    // é‡æ–°æŒ‡å®šç”Ÿæˆæ•µäºº
     private void CreateBattleEnemy()
     {
         uiGameMainView.ApplyRoleRect();
@@ -159,9 +362,9 @@ public class BattlePanel : PanelBase
     private void DieAction(bool isTomatoModel = false)
     {
         m_isAlive = false;
-        // §ó·s¨¤¦â¦º¤`¦¸¼Æ
+        // æ›´æ–°è§’è‰²æ­»äº¡æ¬¡æ•¸
         StorageManager.instance.StorageData.AddEnemyKillCount(m_curBattleRole.key , isTomatoModel);
-        // §ó·sºX¼Ğ
+        // æ›´æ–°æ——æ¨™
         if (m_curBattleRole.KillToAddFlagReference != null)
         {
             StorageManager.instance.StorageData.AddFlagStorageValue(m_curBattleRole.KillToAddFlagReference?.GetKey());
@@ -174,16 +377,16 @@ public class BattlePanel : PanelBase
     {
         if (active == false)
             return;
-        // ¥Í¦¨ºt¥X¤¤¤£³B²z
+        // ç”Ÿæˆæ¼”å‡ºä¸­ä¸è™•ç†
         if (m_isAlive == false)
             return;
 
         if (m_tomatoManager.isTomatoTime)
         {
-            // Àx»W¯à¶q
+            // å„²è“„èƒ½é‡
             m_tomatoHitStack ++;
             PlayHit("?");
-            // »İ­n¤@­ÓÀx»W¯à¶qªºªí²{
+            // éœ€è¦ä¸€å€‹å„²è“„èƒ½é‡çš„è¡¨ç¾
             return;
         }
 
@@ -217,7 +420,7 @@ public class BattlePanel : PanelBase
     }
 
     /// <summary>
-    /// ¼½©ñ¶Ë®`¨Ó·½¬O§_¬° TomatoTime
+    /// æ’­æ”¾å‚·å®³ä¾†æºæ˜¯å¦ç‚º TomatoTime
     /// </summary>
     /// <param name="hitValue"></param>
     /// <param name="isFromTomatoTime"></param>


### PR DESCRIPTION
## Summary
- display Traditional Chinese localization previews for TalkScriptableObject entries in the inspector
- add an editor utility to read localization keys for the preview
- expose enemy HUD helpers and wire a coroutine-driven battle talk flow that rotates lines by duration and conditions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e297b9c00883228473f38c13ec9257